### PR TITLE
map=>list: compatibility with python3

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,11 +1,12 @@
 from geode import *
-import numpy as np
 from pprint import pprint
+import numpy as np
+import os.path
 
 ## read expression data
 mat = []
 genes = []
-with open ('example_expression_data.txt') as f:
+with open (os.path.join(os.path.dirname(__file__), 'example_expression_data.txt')) as f:
 	next(f)
 	for line in f:
 		sl = line.strip().split('\t')

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -11,7 +11,7 @@ with open (os.path.join(os.path.dirname(__file__), 'example_expression_data.txt'
 	for line in f:
 		sl = line.strip().split('\t')
 		gene = sl[0]
-		row = map(float, sl[1:])
+		row = list(map(float, sl[1:]))
 		genes.append(gene)
 		mat.append(row)
 mat = np.array(mat)

--- a/geode/geode.py
+++ b/geode/geode.py
@@ -29,7 +29,7 @@ def chdir(data, sampleclass, genes, gamma=1., sort=True, calculate_sig=False, nn
 	
 	## check input
 	data.astype(float)
-	sampleclass = np.array(map(int, sampleclass))
+	sampleclass = np.array(list(map(int, sampleclass)))
 	# masks
 	m_non0 = sampleclass != 0
 	m1 = sampleclass[m_non0] == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.17.0
+scikit-learn==0.21.3
+scipy==1.3.1

--- a/tests/geode_test.py
+++ b/tests/geode_test.py
@@ -12,7 +12,7 @@ class TestChdir(unittest.TestCase):
 			for line in f:
 				sl = line.strip().split('\t')
 				gene = sl[0]
-				row = map(float, sl[1:])
+				row = list(map(float, sl[1:]))
 				genes.append(gene)
 				mat.append(row)
 

--- a/tests/geode_test.py
+++ b/tests/geode_test.py
@@ -1,3 +1,4 @@
+import os.path
 import unittest
 import numpy as np
 import geode
@@ -6,7 +7,7 @@ class TestChdir(unittest.TestCase):
 	def setUp(self): # to get example data
 		mat = []
 		genes = []
-		with open ('../examples/example_expression_data.txt') as f:
+		with open (os.path.join(os.path.dirname(__file__), '../examples/example_expression_data.txt')) as f:
 			next(f)
 			for line in f:
 				sl = line.strip().split('\t')


### PR DESCRIPTION
Using this library in python3 has an issue with sampleclass--this is because maps do not return lists; so `np.array(map(...))` becomes weird. If we coerce it to a list before np.array, this should work in both python3 and python2; `np.array(list(map(...)))`.
